### PR TITLE
Move Search button closer to Filter on Show Conferences tab.

### DIFF
--- a/ConferenceCentral_Complete/static/partials/show_conferences.html
+++ b/ConferenceCentral_Complete/static/partials/show_conferences.html
@@ -25,7 +25,7 @@
     <div class="row row-offcanvas row-offcanvas-right" ng-class="{active: isOffcanvasEnabled}">
         <div class="col-xs-12 col-sm-8">
 
-            <button ng-click="queryConferences();" class="btn btn-primary">
+            <button ng-click="queryConferences();" class="btn btn-primary pull-right">
                 <i class="glyphicon glyphicon-search"></i> Search
             </button>
 

--- a/Lesson_2/00_Conference_Central/static/partials/show_conferences.html
+++ b/Lesson_2/00_Conference_Central/static/partials/show_conferences.html
@@ -25,7 +25,7 @@
     <div class="row row-offcanvas row-offcanvas-right" ng-class="{active: isOffcanvasEnabled}">
         <div class="col-xs-12 col-sm-8">
 
-            <button ng-click="queryConferences();" class="btn btn-primary">
+            <button ng-click="queryConferences();" class="btn btn-primary pull-right">
                 <i class="glyphicon glyphicon-search"></i> Search
             </button>
 

--- a/Lesson_3/00_Conference_Central/static/partials/show_conferences.html
+++ b/Lesson_3/00_Conference_Central/static/partials/show_conferences.html
@@ -25,7 +25,7 @@
     <div class="row row-offcanvas row-offcanvas-right" ng-class="{active: isOffcanvasEnabled}">
         <div class="col-xs-12 col-sm-8">
 
-            <button ng-click="queryConferences();" class="btn btn-primary">
+            <button ng-click="queryConferences();" class="btn btn-primary pull-right">
                 <i class="glyphicon glyphicon-search"></i> Search
             </button>
 

--- a/Lesson_4/00_Conference_Central/static/partials/show_conferences.html
+++ b/Lesson_4/00_Conference_Central/static/partials/show_conferences.html
@@ -25,7 +25,7 @@
     <div class="row row-offcanvas row-offcanvas-right" ng-class="{active: isOffcanvasEnabled}">
         <div class="col-xs-12 col-sm-8">
 
-            <button ng-click="queryConferences();" class="btn btn-primary">
+            <button ng-click="queryConferences();" class="btn btn-primary pull-right">
                 <i class="glyphicon glyphicon-search"></i> Search
             </button>
 

--- a/Lesson_5/00_Conference_Central/static/partials/show_conferences.html
+++ b/Lesson_5/00_Conference_Central/static/partials/show_conferences.html
@@ -25,7 +25,7 @@
     <div class="row row-offcanvas row-offcanvas-right" ng-class="{active: isOffcanvasEnabled}">
         <div class="col-xs-12 col-sm-8">
 
-            <button ng-click="queryConferences();" class="btn btn-primary">
+            <button ng-click="queryConferences();" class="btn btn-primary pull-right">
                 <i class="glyphicon glyphicon-search"></i> Search
             </button>
 


### PR DESCRIPTION
@pmallory @GundegaDekena @karlud 

Hopefully this is a quick thumbs-up...

**Minor Problem for Students:**

There was some student confusion about using the Search functionality on the Show Conferences tab. It was assumed that you could click Enter/Return to update the query results using the Filter you just made. That does not work. You have to click the Search button to update the results.

**Solution:**

Because of this confusion I've moved the Search button closer to the Filter button so that when clicking Enter/Return doesn't work for a student they will immediately try to click the Search button.
